### PR TITLE
fix: allow persistence of custom shareholder display IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,7 @@ build/
 
 ### VS Code ###
 .vscode/
-/midas.db
+
+### DB files ###
+*.db
+*.db.bak

--- a/src/main/java/de/nihas101/midas/shareholders/entity/ShareholderEntity.java
+++ b/src/main/java/de/nihas101/midas/shareholders/entity/ShareholderEntity.java
@@ -24,8 +24,7 @@ public class ShareholderEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Column(name = "display_id", insertable = false)
-    @Generated(event = {EventType.INSERT})
+    @Column(name = "display_id")
     private Integer displayId;
 
     @Column(name = "first_name", nullable = false)

--- a/src/main/java/de/nihas101/midas/shareholders/service/ShareholdersService.java
+++ b/src/main/java/de/nihas101/midas/shareholders/service/ShareholdersService.java
@@ -40,7 +40,6 @@ public class ShareholdersService implements ShareholdersReader, ShareholdersWrit
         if (shareholder.getId() != null) {
             throw new IllegalArgumentException("ShareholdersService#create with shareholder.getId() != null");
         }
-        // TODO: This can cause the display id to be overwritten (maybe, could also be a frontend issue)
         repository.save(ShareholderEntity.fromDto(shareholder));
     }
 

--- a/src/test/java/de/nihas101/midas/TestDatabaseInitializer.java
+++ b/src/test/java/de/nihas101/midas/TestDatabaseInitializer.java
@@ -1,0 +1,39 @@
+package de.nihas101.midas;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.Environment;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+@Slf4j
+public class TestDatabaseInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        final Environment env = applicationContext.getEnvironment();
+        if (!Arrays.asList(env.getActiveProfiles()).contains("test")) {
+            return;
+        }
+        final String dbUrl = env.getProperty("spring.datasource.url");
+        if (dbUrl == null || !dbUrl.startsWith("jdbc:sqlite:")) {
+            return;
+        }
+        final String dbPath = dbUrl.substring("jdbc:sqlite:".length());
+        // Handle optional file: prefix or memory markers if necessary,
+        // but for "midas-test.db" it's straightforward.
+        if (dbPath.contains(":memory:") || dbPath.isEmpty()) {
+            return;
+        }
+
+        log.info("Cleaning up database from last test run...");
+        try {
+            Files.deleteIfExists(Paths.get(dbPath));
+        } catch (IOException e) {
+            log.error("TestDatabaseInitializer: Failed to delete test database file {}: {}", dbPath, e.getMessage());
+        }
+    }
+}

--- a/src/test/java/de/nihas101/midas/shareholders/service/ShareholderPersistenceTest.java
+++ b/src/test/java/de/nihas101/midas/shareholders/service/ShareholderPersistenceTest.java
@@ -1,0 +1,67 @@
+package de.nihas101.midas.shareholders.service;
+
+import de.nihas101.midas.shareholders.dto.Shareholder;
+import de.nihas101.midas.shareholders.repository.ShareholdersRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ShareholderPersistenceTest {
+
+    @Autowired
+    private ShareholdersService service;
+
+    @Autowired
+    private ShareholdersRepository repository;
+
+    @Test
+    void create_withDisplayId_shouldPersistDisplayId() {
+        // Given
+        int customDisplayId = 999;
+        Shareholder dto = new Shareholder(null, customDisplayId, "John", "Doe");
+
+        // When
+        service.create(dto);
+
+        // Then
+        Shareholder saved = service.shareholders().toList().stream()
+                .filter(s -> s.getFirstName().equals("John") && s.getLastName().equals("Doe"))
+                .findFirst()
+                .orElseThrow();
+
+        // This is expected to FAIL currently because of insertable = false
+        assertEquals(customDisplayId, saved.getDisplayId(), "The custom display ID should have been persisted");
+    }
+
+    @Test
+    void update_withDisplayId_shouldPersistDisplayId() {
+        // Given
+        Shareholder dto = new Shareholder(null, null, "Jane", "Doe");
+        service.create(dto);
+        
+        Shareholder saved = service.shareholders().toList().stream()
+                .filter(s -> s.getFirstName().equals("Jane") && s.getLastName().equals("Doe"))
+                .findFirst()
+                .orElseThrow();
+        
+        assertEquals(saved.getId(), saved.getDisplayId(), "If no display ID is provided, it should default to the database ID");
+        
+        int originalDisplayId = saved.getDisplayId();
+        int newDisplayId = 888;
+        saved.setDisplayId(newDisplayId);
+
+        // When
+        service.update(saved);
+
+        // Then
+        Shareholder updated = service.shareholder(saved.getId());
+        assertEquals(newDisplayId, updated.getDisplayId(), "The new display ID should have been persisted during update");
+        assertNotEquals(originalDisplayId, updated.getDisplayId());
+    }
+}

--- a/src/test/resources/META-INF/spring.factories
+++ b/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.context.ApplicationContextInitializer=de.nihas101.midas.TestDatabaseInitializer

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:sqlite:midas-test.db
+spring.datasource.driver-class-name=org.sqlite.JDBC
+spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect
+spring.jpa.hibernate.ddl-auto=none
+spring.liquibase.enabled=true


### PR DESCRIPTION
The `display_id` for shareholders was not being persisted during creation because it was marked as `insertable = false` and `@Generated`. This led to the database always using the auto-incremented `id`, even if a specific ID was provided in the UI.