### PR TITLE
Add shareholders displayId to XSLX export

### DIFF
--- a/src/main/java/de/nihas101/midas/export/accountstatement/AccountStatementExportDataSource.java
+++ b/src/main/java/de/nihas101/midas/export/accountstatement/AccountStatementExportDataSource.java
@@ -22,6 +22,7 @@ public class AccountStatementExportDataSource implements ExportDataSource {
 
     private List<String> getHeaders(final MessageSource messageSource, final Locale locale) {
         return List.of(
+                messageSource.getMessage("bookings.shareholder.display-id", null, locale),
                 messageSource.getMessage("bookings.shareholder", null, locale),
                 messageSource.getMessage("account-statements.table.id", null, locale),
                 messageSource.getMessage("account-statements.table.date", null, locale),
@@ -50,6 +51,7 @@ public class AccountStatementExportDataSource implements ExportDataSource {
 
     private List<Object> toGenericRow(final ExportRow exportRow) {
         List<Object> row = new ArrayList<>();
+        row.add(exportRow.shareholderId());
         row.add(exportRow.shareholderName());
         row.add(exportRow.id() != null ? exportRow.id() : "");
         row.add(exportRow.date());

--- a/src/main/java/de/nihas101/midas/export/accountstatement/AccountStatementsRowExtractor.java
+++ b/src/main/java/de/nihas101/midas/export/accountstatement/AccountStatementsRowExtractor.java
@@ -3,6 +3,8 @@ package de.nihas101.midas.export.accountstatement;
 import de.nihas101.midas.accountstatement.runningtotal.RunningTotalAccountStatement;
 import de.nihas101.midas.accountstatement.runningtotal.RunningTotalAccountStatements;
 import de.nihas101.midas.accountstatement.service.RunningTotalAccountStatementService;
+import de.nihas101.midas.export.sort.DisplayIdExportRowSort;
+import de.nihas101.midas.export.sort.ExportRowSort;
 import de.nihas101.midas.shareholders.dto.Shareholder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
@@ -12,11 +14,12 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.Year;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static java.math.BigDecimal.ZERO;
 
 @RequiredArgsConstructor
 public class AccountStatementsRowExtractor {
@@ -26,21 +29,35 @@ public class AccountStatementsRowExtractor {
     private final RunningTotalAccountStatementService runningTotalAccountStatementService;
     private final MessageSource messageSource;
     private final Locale locale;
+    private final ExportRowSort exportRowSort;
+
+    public AccountStatementsRowExtractor(
+            final List<Shareholder> shareholders,
+            final LocalDate startDate,
+            final LocalDate endDate,
+            final RunningTotalAccountStatementService runningTotalAccountStatementService,
+            final MessageSource messageSource,
+            final Locale locale
+    ) {
+        this(
+                shareholders,
+                startDate,
+                endDate,
+                runningTotalAccountStatementService,
+                messageSource,
+                locale,
+                new DisplayIdExportRowSort()
+        );
+    }
 
     public List<ExportRow> rows() {
         return shareholders.stream()
-                .map(this::rowsForShareholder)
+                .map(shareholder -> IntStream.rangeClosed(startDate.getYear(), endDate.getYear())
+                        .mapToObj(yearValue -> rowsForYear(shareholder, yearValue)).flatMap(Collection::stream)
+                        .toList())
                 .flatMap(Collection::stream)
-                .sorted(Comparator.comparing(ExportRow::shareholderName).thenComparing(ExportRow::date))
+                .sorted(exportRowSort)
                 .collect(Collectors.toList());
-    }
-
-    private List<ExportRow> rowsForShareholder(final Shareholder shareholder) {
-        return IntStream.rangeClosed(startDate.getYear(), endDate.getYear())
-                .mapToObj(yearValue ->
-                        rowsForYear(shareholder, yearValue)
-                ).flatMap(Collection::stream)
-                .toList();
     }
 
     private List<ExportRow> rowsForYear(
@@ -60,18 +77,27 @@ public class AccountStatementsRowExtractor {
                 .stream()
                 .filter(stmt -> isWithinRange(stmt.date()))
                 .filter(stmt -> !stmt.isHidden())
-                .map(stmt -> exportRow(shareholderName, stmt)).toList();
+                .map(stmt -> exportRow(
+                        shareholder.getDisplayId(),
+                        shareholderName,
+                        stmt
+                )).toList();
     }
 
-    private ExportRow exportRow(final String shareholderName, final RunningTotalAccountStatement stmt) {
+    private ExportRow exportRow(
+            final Integer shareholderId,
+            final String shareholderName,
+            final RunningTotalAccountStatement stmt
+    ) {
         final BigDecimal amount = stmt.amount().toBigDecimal();
-        final BigDecimal debit = amount.compareTo(BigDecimal.ZERO) < 0
+        final BigDecimal debit = amount.compareTo(ZERO) < 0
                 ? amount.abs()
-                : BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
-        final BigDecimal credit = amount.compareTo(BigDecimal.ZERO) >= 0
+                : ZERO.setScale(2, RoundingMode.HALF_UP);
+        final BigDecimal credit = amount.compareTo(ZERO) >= 0
                 ? amount
-                : BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+                : ZERO.setScale(2, RoundingMode.HALF_UP);
         return new ExportRow(
+                shareholderId,
                 shareholderName,
                 stmt.id(),
                 stmt.date(),

--- a/src/main/java/de/nihas101/midas/export/accountstatement/ExportRow.java
+++ b/src/main/java/de/nihas101/midas/export/accountstatement/ExportRow.java
@@ -1,9 +1,12 @@
 package de.nihas101.midas.export.accountstatement;
 
+import de.nihas101.midas.export.sort.SortableExportRow;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record ExportRow(
+        Integer shareholderId,
         String shareholderName,
         Integer id,
         LocalDate date,
@@ -11,5 +14,5 @@ public record ExportRow(
         BigDecimal debit,
         BigDecimal credit,
         BigDecimal balance
-) {
+) implements SortableExportRow {
 }

--- a/src/main/java/de/nihas101/midas/export/bookings/BookingsExportDataSource.java
+++ b/src/main/java/de/nihas101/midas/export/bookings/BookingsExportDataSource.java
@@ -26,6 +26,7 @@ public class BookingsExportDataSource implements ExportDataSource {
 
     private List<String> getHeaders(final MessageSource messageSource, final Locale locale) {
         return List.of(
+                messageSource.getMessage("bookings.shareholder.display-id", null, locale),
                 messageSource.getMessage("bookings.shareholder", null, locale),
                 messageSource.getMessage("bookings.table.id", null, locale),
                 messageSource.getMessage("bookings.date", null, locale),
@@ -55,22 +56,23 @@ public class BookingsExportDataSource implements ExportDataSource {
         );
     }
 
-    private List<Object> toGenericRow(ExportRow row) {
-        final List<Object> list = new ArrayList<>();
-        list.add(row.shareholderName());
-        list.add(row.id() != null ? row.id() : "");
-        list.add(row.date());
-        list.add(row.comment());
+    private List<Object> toGenericRow(ExportRow exportRow) {
+        final List<Object> row = new ArrayList<>();
+        row.add(exportRow.shareholderId());
+        row.add(exportRow.shareholderName());
+        row.add(exportRow.id() != null ? exportRow.id() : "");
+        row.add(exportRow.date());
+        row.add(exportRow.comment());
 
         // Map the amount to the correct column based on type, use 0.00 for others
-        list.add(getValueForType(row, BookingType.WITHDRAWAL.name()));
-        list.add(getValueForType(row, BookingType.TAX_PREVIOUS_YEAR.name()));
-        list.add(getValueForType(row, BookingType.TAX_CREDIT.name()));
-        list.add(getValueForType(row, BookingType.INTEREST.name()));
-        list.add(getValueForType(row, BookingType.COMPENSATION.name()));
-        list.add(getValueForType(row, BookingsRowExtractor.TYPE_OPENING_BALANCE));
+        row.add(getValueForType(exportRow, BookingType.WITHDRAWAL.name()));
+        row.add(getValueForType(exportRow, BookingType.TAX_PREVIOUS_YEAR.name()));
+        row.add(getValueForType(exportRow, BookingType.TAX_CREDIT.name()));
+        row.add(getValueForType(exportRow, BookingType.INTEREST.name()));
+        row.add(getValueForType(exportRow, BookingType.COMPENSATION.name()));
+        row.add(getValueForType(exportRow, BookingsRowExtractor.TYPE_OPENING_BALANCE));
 
-        return list;
+        return row;
     }
 
     private BigDecimal getValueForType(ExportRow row, String typeName) {

--- a/src/main/java/de/nihas101/midas/export/bookings/BookingsRowExtractor.java
+++ b/src/main/java/de/nihas101/midas/export/bookings/BookingsRowExtractor.java
@@ -1,6 +1,8 @@
 package de.nihas101.midas.export.bookings;
 
 import de.nihas101.midas.bookings.service.BookingsReader;
+import de.nihas101.midas.export.sort.DisplayIdExportRowSort;
+import de.nihas101.midas.export.sort.ExportRowSort;
 import de.nihas101.midas.openingbalance.dto.OpeningBalance;
 import de.nihas101.midas.openingbalance.service.OpeningBalanceService;
 import de.nihas101.midas.shareholders.dto.Shareholder;
@@ -11,7 +13,6 @@ import java.time.LocalDate;
 import java.time.Year;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -29,13 +30,35 @@ public class BookingsRowExtractor {
     private final OpeningBalanceService openingBalanceService;
     private final MessageSource messageSource;
     private final Locale locale;
+    private final ExportRowSort exportRowSort;
+
+    public BookingsRowExtractor(
+            final List<Shareholder> shareholders,
+            final LocalDate startDate,
+            final LocalDate endDate,
+            final BookingsReader bookingsReader,
+            final OpeningBalanceService openingBalanceService,
+            final MessageSource messageSource,
+            final Locale locale
+    ) {
+        this(
+                shareholders,
+                startDate,
+                endDate,
+                bookingsReader,
+                openingBalanceService,
+                messageSource,
+                locale,
+                new DisplayIdExportRowSort()
+        );
+    }
 
     public List<ExportRow> rows() {
         return shareholders.stream()
                 .flatMap(shareholder -> IntStream.rangeClosed(startDate.getYear(), endDate.getYear())
                         .mapToObj(yearValue -> exportRows(shareholder, yearValue))
                         .flatMap(Collection::stream))
-                .sorted(Comparator.comparing(ExportRow::shareholderName).thenComparing(ExportRow::date))
+                .sorted(exportRowSort)
                 .toList();
     }
 
@@ -67,6 +90,7 @@ public class BookingsRowExtractor {
 
         return Optional.of(
                 new ExportRow(
+                        shareholder.getDisplayId(),
                         shareholderName,
                         null,
                         openingBalanceDate,
@@ -88,6 +112,7 @@ public class BookingsRowExtractor {
                 .stream()
                 .map(b ->
                         new ExportRow(
+                                shareholder.getDisplayId(),
                                 shareholderName,
                                 b.getId(),
                                 b.getDate(),

--- a/src/main/java/de/nihas101/midas/export/bookings/ExportRow.java
+++ b/src/main/java/de/nihas101/midas/export/bookings/ExportRow.java
@@ -1,14 +1,17 @@
 package de.nihas101.midas.export.bookings;
 
+import de.nihas101.midas.export.sort.SortableExportRow;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record ExportRow(
+        Integer shareholderId,
         String shareholderName,
         Integer id,
         LocalDate date,
         String comment,
         String typeName,
         BigDecimal amount
-) {
+) implements SortableExportRow {
 }

--- a/src/main/java/de/nihas101/midas/export/interest/ExportRow.java
+++ b/src/main/java/de/nihas101/midas/export/interest/ExportRow.java
@@ -1,9 +1,12 @@
 package de.nihas101.midas.export.interest;
 
+import de.nihas101.midas.export.sort.SortableExportRow;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record ExportRow(
+        Integer shareholderId,
         String shareholderName,
         LocalDate date,
         BigDecimal transactions,
@@ -13,5 +16,10 @@ public record ExportRow(
         Integer days,
         BigDecimal interestNumber,
         BigDecimal rate
-) {
+) implements SortableExportRow {
+
+    @Override
+    public Integer id() {
+        return 0;
+    }
 }

--- a/src/main/java/de/nihas101/midas/export/interest/InterestExportDataSource.java
+++ b/src/main/java/de/nihas101/midas/export/interest/InterestExportDataSource.java
@@ -34,17 +34,18 @@ public class InterestExportDataSource implements ExportDataSource {
     }
 
     private List<Object> toGenericRow(final ExportRow exportRow) {
-        List<Object> list = new ArrayList<>();
-        list.add(exportRow.shareholderName());
-        list.add(exportRow.date());
-        list.add(exportRow.transactions());
-        list.add(exportRow.transSH());
-        list.add(exportRow.balance());
-        list.add(exportRow.balanceSH());
-        list.add(exportRow.days());
-        list.add(exportRow.interestNumber());
-        list.add(exportRow.rate());
-        return list;
+        List<Object> row = new ArrayList<>();
+        row.add(exportRow.shareholderId());
+        row.add(exportRow.shareholderName());
+        row.add(exportRow.date());
+        row.add(exportRow.transactions());
+        row.add(exportRow.transSH());
+        row.add(exportRow.balance());
+        row.add(exportRow.balanceSH());
+        row.add(exportRow.days());
+        row.add(exportRow.interestNumber());
+        row.add(exportRow.rate());
+        return row;
     }
 
     private String getSheetName(final MessageSource messageSource, final Locale locale) {
@@ -53,6 +54,7 @@ public class InterestExportDataSource implements ExportDataSource {
 
     private List<String> getHeaders(final MessageSource messageSource, final Locale locale) {
         return List.of(
+                messageSource.getMessage("bookings.shareholder.display-id", null, locale),
                 messageSource.getMessage("bookings.shareholder", null, locale),
                 messageSource.getMessage("interest.table.month", null, locale),
                 messageSource.getMessage("interest.table.transactions", null, locale),

--- a/src/main/java/de/nihas101/midas/export/interest/InterestRowExtractor.java
+++ b/src/main/java/de/nihas101/midas/export/interest/InterestRowExtractor.java
@@ -2,6 +2,8 @@ package de.nihas101.midas.export.interest;
 
 import de.nihas101.midas.bookings.dto.Bookings;
 import de.nihas101.midas.bookings.service.BookingsReader;
+import de.nihas101.midas.export.sort.DisplayIdExportRowSort;
+import de.nihas101.midas.export.sort.ExportRowSort;
 import de.nihas101.midas.interest.InterestCalculation;
 import de.nihas101.midas.interest.dto.InterestRate;
 import de.nihas101.midas.interest.interestamount.Interest;
@@ -17,12 +19,13 @@ import java.time.LocalDate;
 import java.time.Month;
 import java.time.Year;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
+import static java.math.BigDecimal.ZERO;
 
 @RequiredArgsConstructor
 public class InterestRowExtractor {
@@ -32,13 +35,31 @@ public class InterestRowExtractor {
     private final LocalDate endDate;
     private final BookingsReader bookingsReader;
     private final InterestRateService interestRateService;
+    private final ExportRowSort exportRowSort;
+
+    public InterestRowExtractor(
+            final List<Shareholder> shareholders,
+            final LocalDate startDate,
+            final LocalDate endDate,
+            final BookingsReader bookingsReader,
+            final InterestRateService interestRateService
+    ) {
+        this(
+                shareholders,
+                startDate,
+                endDate,
+                bookingsReader,
+                interestRateService,
+                new DisplayIdExportRowSort()
+        );
+    }
 
     public List<ExportRow> rows() {
         return shareholders.stream()
                 .flatMap(shareholder -> IntStream.rangeClosed(startDate.getYear(), endDate.getYear())
                         .mapToObj(Year::of)
                         .flatMap(year -> exportRows(shareholder, year)))
-                .sorted(Comparator.comparing(ExportRow::shareholderName).thenComparing(ExportRow::date))
+                .sorted(exportRowSort)
                 .toList();
     }
 
@@ -48,7 +69,7 @@ public class InterestRowExtractor {
     ) {
         final BigDecimal rate = Optional.ofNullable(interestRateService.interestRate(shareholder.getId(), year))
                 .map(InterestRate::getInterestRate)
-                .orElse(BigDecimal.ZERO);
+                .orElse(ZERO);
         final Bookings bookings = bookingsReader.bookingsForShareholderAndYear(shareholder.getId(), year);
         final InterestCalculation calc = new InterestCalculation(bookings, year, rate);
         return Arrays.stream(Month.values())
@@ -63,6 +84,7 @@ public class InterestRowExtractor {
 
                     final String shareholderName = shareholder.getFirstName() + " " + shareholder.getLastName();
                     return new ExportRow(
+                            shareholder.getDisplayId(),
                             shareholderName,
                             date,
                             trans.toBigDecimal().abs(),

--- a/src/main/java/de/nihas101/midas/export/sort/DisplayIdExportRowSort.java
+++ b/src/main/java/de/nihas101/midas/export/sort/DisplayIdExportRowSort.java
@@ -1,0 +1,49 @@
+package de.nihas101.midas.export.sort;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Comparator;
+
+@RequiredArgsConstructor
+public class DisplayIdExportRowSort implements ExportRowSort {
+
+    private final Comparator<SortableExportRow> exportRowComparator = Comparator.comparing(SortableExportRow::shareholderId)
+            .thenComparing(SortableExportRow::date)
+            .thenComparing(SortableExportRow::id);
+
+    @Override
+    public int compare(
+            final SortableExportRow a,
+            final SortableExportRow b
+    ) {
+        if (a == null && b == null) {
+            return 0;
+        }
+        if (a == null) {
+            return 1;
+        }
+        if (b == null) {
+            return -1;
+        }
+        if (a.shareholderId() == null && b.shareholderId() == null) {
+            return 0;
+        }
+        if (a.shareholderId() == null) {
+            return 1;
+        }
+        if (b.shareholderId() == null) {
+            return -1;
+        }
+        if (a.date() == null && b.date() == null) {
+            return 0;
+        }
+        if (a.date() == null) {
+            return 1;
+        }
+        if (b.date() == null) {
+            return -1;
+        }
+
+        return exportRowComparator.compare(a, b);
+    }
+}

--- a/src/main/java/de/nihas101/midas/export/sort/ExportRowSort.java
+++ b/src/main/java/de/nihas101/midas/export/sort/ExportRowSort.java
@@ -1,0 +1,6 @@
+package de.nihas101.midas.export.sort;
+
+import java.util.Comparator;
+
+public interface ExportRowSort extends Comparator<SortableExportRow> {
+}

--- a/src/main/java/de/nihas101/midas/export/sort/SortableExportRow.java
+++ b/src/main/java/de/nihas101/midas/export/sort/SortableExportRow.java
@@ -1,0 +1,12 @@
+package de.nihas101.midas.export.sort;
+
+import java.time.LocalDate;
+
+public interface SortableExportRow {
+
+    Integer shareholderId();
+
+    LocalDate date();
+
+    Integer id();
+}

--- a/src/main/java/de/nihas101/midas/export/xlsx/XlsxExportTarget.java
+++ b/src/main/java/de/nihas101/midas/export/xlsx/XlsxExportTarget.java
@@ -81,7 +81,6 @@ public class XlsxExportTarget implements ExportTarget, AutoCloseable {
         return workbook.createSheet(sheetName);
     }
 
-    // TODO: Add the display id here and sort by that (instead of the shareholder name)
     private void writeHeader(final Sheet sheet, final List<String> headers) {
         final Row headerRow = sheet.createRow(0);
         for (int i = 0; i < headers.size(); i++) {

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -21,6 +21,7 @@ bookings.table.delete.confirmation.title=Delete Booking
 bookings.table.delete.confirmation.message=Are you sure you want to remove this booking ({0}) from {1} for {2}?
 bookings=Bookings
 bookings.header.title=Shareholder - Bookings for {0}
+bookings.shareholder.display-id=ID
 bookings.shareholder=Shareholder
 bookings.year=Year
 bookings.date=Date

--- a/src/main/resources/i18n/messages_de.properties
+++ b/src/main/resources/i18n/messages_de.properties
@@ -21,6 +21,7 @@ bookings.table.delete.confirmation.title=Buchung löschen
 bookings.table.delete.confirmation.message=Sind Sie sicher, dass Sie diese Buchung ({0}) vom {1} über {2} entfernen möchten?
 bookings=Buchungen
 bookings.header.title=Gesellschafter - Buchungen für {0}
+bookings.shareholder.display-id=ID
 bookings.shareholder=Gesellschafter
 bookings.year=Jahr
 bookings.date=Datum

--- a/src/test/java/de/nihas101/midas/export/AccountStatementExportDataSourceTest.java
+++ b/src/test/java/de/nihas101/midas/export/AccountStatementExportDataSourceTest.java
@@ -116,21 +116,22 @@ class AccountStatementExportDataSourceTest {
         assertEquals(2, rows.size());
 
         // Verify Alice's row (Sorted by name)
-        List<Object> row1 = rows.get(0);
-        assertEquals("Alice A", row1.get(0));
-        assertEquals(101, row1.get(1));
-        assertEquals(LocalDate.of(2023, 5, 10), row1.get(2));
-        assertEquals("Withdrawal", row1.get(3));
+        List<Object> row1 = rows.getFirst();
+        assertEquals(1, row1.get(0));
+        assertEquals("Alice A", row1.get(1));
+        assertEquals(101, row1.get(2));
+        assertEquals(LocalDate.of(2023, 5, 10), row1.get(3));
+        assertEquals("Withdrawal", row1.get(4));
         // Use compareTo for BigDecimals to ignore scale differences
-        assertEquals(0, ((BigDecimal) row1.get(4)).compareTo(new BigDecimal("50.00"))); // Debit
-        assertEquals(0, ((BigDecimal) row1.get(5)).compareTo(new BigDecimal("0.00")));  // Credit
-        assertEquals(0, ((BigDecimal) row1.get(6)).compareTo(new BigDecimal("100.00"))); // Balance
+        assertEquals(0, ((BigDecimal) row1.get(5)).compareTo(new BigDecimal("50.00"))); // Debit
+        assertEquals(0, ((BigDecimal) row1.get(6)).compareTo(new BigDecimal("0.00")));  // Credit
+        assertEquals(0, ((BigDecimal) row1.get(7)).compareTo(new BigDecimal("100.00"))); // Balance
 
         // Verify Bob's row
         List<Object> row2 = rows.get(1);
-        assertEquals("Bob B", row2.get(0));
-        assertEquals(0, ((BigDecimal) row2.get(4)).compareTo(new BigDecimal("0.00")));  // Debit
-        assertEquals(0, ((BigDecimal) row2.get(5)).compareTo(new BigDecimal("200.00"))); // Credit
+        assertEquals("Bob B", row2.get(1));
+        assertEquals(0, ((BigDecimal) row2.get(5)).compareTo(new BigDecimal("0.00")));  // Debit
+        assertEquals(0, ((BigDecimal) row2.get(6)).compareTo(new BigDecimal("200.00"))); // Credit
     }
 
     @Test

--- a/src/test/java/de/nihas101/midas/export/BookingsExportDataSourceTest.java
+++ b/src/test/java/de/nihas101/midas/export/BookingsExportDataSourceTest.java
@@ -106,21 +106,21 @@ class BookingsExportDataSourceTest {
         // Verify Alice's rows (Sorted by name)
         // Alice OB (01.01.2023)
         List<Object> row1 = rows.getFirst();
-        assertEquals("Alice A", row1.get(0));
-        assertEquals("", row1.get(1));
-        assertEquals(LocalDate.of(2023, 1, 1), row1.get(2));
-        assertEquals(0, ((BigDecimal) row1.get(9)).compareTo(new BigDecimal("1000.00"))); // OB column
+        assertEquals("Alice A", row1.get(1));
+        assertEquals("", row1.get(2));
+        assertEquals(LocalDate.of(2023, 1, 1), row1.get(3));
+        assertEquals(0, ((BigDecimal) row1.get(10)).compareTo(new BigDecimal("1000.00"))); // OB column
 
         // Alice Booking (10.05.2023)
         List<Object> row2 = rows.get(1);
-        assertEquals("Alice A", row2.get(0));
-        assertEquals(101, row2.get(1));
-        assertEquals(0, ((BigDecimal) row2.get(4)).compareTo(new BigDecimal("-100.00"))); // Withdrawal column
+        assertEquals("Alice A", row2.get(1));
+        assertEquals(101, row2.get(2));
+        assertEquals(0, ((BigDecimal) row2.get(5)).compareTo(new BigDecimal("-100.00"))); // Withdrawal column
 
         // Bob Booking (15.06.2023)
         List<Object> row3 = rows.get(2);
-        assertEquals("Bob B", row3.get(0));
-        assertEquals(0, ((BigDecimal) row3.get(7)).compareTo(new BigDecimal("5.50"))); // Interest column
+        assertEquals("Bob B", row3.get(1));
+        assertEquals(0, ((BigDecimal) row3.get(8)).compareTo(new BigDecimal("5.50"))); // Interest column
     }
 
     @Test
@@ -156,7 +156,7 @@ class BookingsExportDataSourceTest {
         ArgumentCaptor<List<List<Object>>> rowsCaptor = ArgumentCaptor.forClass(List.class);
         verify(exportTarget).export(any(), any(), rowsCaptor.capture());
         assertEquals(1, rowsCaptor.getValue().size());
-        assertEquals(1, rowsCaptor.getValue().getFirst().get(1)); // Only bIn remains
+        assertEquals(1, rowsCaptor.getValue().getFirst().get(2)); // Only bIn remains
     }
 
     @Test

--- a/src/test/java/de/nihas101/midas/export/interest/InterestExportDataSourceTest.java
+++ b/src/test/java/de/nihas101/midas/export/interest/InterestExportDataSourceTest.java
@@ -50,6 +50,7 @@ class InterestExportDataSourceTest {
     @Test
     void export_callsTargetWithFormattedData() {
         ExportRow row1 = new ExportRow(
+                1,
                 "Alice A",
                 LocalDate.of(2023, 1, 31),
                 new BigDecimal("100.00"),
@@ -71,15 +72,15 @@ class InterestExportDataSourceTest {
         assertEquals(1, resultRows.size());
 
         List<Object> resultRow = resultRows.getFirst();
-        assertEquals("Alice A", resultRow.get(0));
-        assertEquals(LocalDate.of(2023, 1, 31), resultRow.get(1));
-        assertEquals(new BigDecimal("100.00"), resultRow.get(2));
-        assertEquals("H", resultRow.get(3));
-        assertEquals(new BigDecimal("1000.00"), resultRow.get(4));
-        assertEquals("H", resultRow.get(5));
-        assertEquals(30, resultRow.get(6));
-        assertEquals(new BigDecimal("5"), resultRow.get(7));
-        assertEquals(new BigDecimal("2.5"), resultRow.get(8));
+        assertEquals("Alice A", resultRow.get(1));
+        assertEquals(LocalDate.of(2023, 1, 31), resultRow.get(2));
+        assertEquals(new BigDecimal("100.00"), resultRow.get(3));
+        assertEquals("H", resultRow.get(4));
+        assertEquals(new BigDecimal("1000.00"), resultRow.get(5));
+        assertEquals("H", resultRow.get(6));
+        assertEquals(30, resultRow.get(7));
+        assertEquals(new BigDecimal("5"), resultRow.get(8));
+        assertEquals(new BigDecimal("2.5"), resultRow.get(9));
     }
 
     @Test
@@ -94,6 +95,7 @@ class InterestExportDataSourceTest {
     @Test
     void getHeaders_localizesAllColumns() {
         ExportRow row = new ExportRow(
+                1,
                 "Alice A",
                 LocalDate.of(2023, 1, 31),
                 new BigDecimal("100.00"),

--- a/src/test/java/de/nihas101/midas/export/sort/DisplayIdExportRowSortTest.java
+++ b/src/test/java/de/nihas101/midas/export/sort/DisplayIdExportRowSortTest.java
@@ -1,0 +1,94 @@
+package de.nihas101.midas.export.sort;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+class DisplayIdExportRowSortTest {
+
+    @ParameterizedTest
+    @MethodSource("compareValues")
+    void compare(SortableExportRow a, SortableExportRow b, int expected) {
+        final DisplayIdExportRowSort displayIdExportRowSort = new DisplayIdExportRowSort();
+        Assertions.assertEquals(expected, displayIdExportRowSort.compare(a, b));
+
+    }
+
+    public static Stream<Arguments> compareValues() {
+        return Stream.of(
+                Arguments.of(
+                        new SortableTestRow(1, LocalDate.of(2026, 1, 1), 0),
+                        new SortableTestRow(1, LocalDate.of(2026, 1, 1), 0),
+                        0
+                ),
+                Arguments.of(
+                        new SortableTestRow(1, LocalDate.of(2026, 1, 1), 0),
+                        new SortableTestRow(1, LocalDate.of(2026, 1, 2), 0),
+                        -1
+                ),
+                Arguments.of(
+                        new SortableTestRow(1, LocalDate.of(2026, 1, 2), 0),
+                        new SortableTestRow(1, LocalDate.of(2026, 1, 1), 0),
+                        1
+                ),
+                Arguments.of(
+                        new SortableTestRow(1, LocalDate.of(2026, 1, 1), 0),
+                        new SortableTestRow(2, LocalDate.of(2026, 1, 1), 0),
+                        -1
+                ),
+                Arguments.of(
+                        new SortableTestRow(2, LocalDate.of(2026, 1, 1), 0),
+                        new SortableTestRow(1, LocalDate.of(2026, 1, 1), 0),
+                        1
+                ),
+                Arguments.of(
+                        new SortableTestRow(null, LocalDate.of(2026, 1, 1), 0),
+                        new SortableTestRow(1, LocalDate.of(2026, 1, 1), 0),
+                        1
+                ),
+                Arguments.of(
+                        new SortableTestRow(2, LocalDate.of(2026, 1, 1), 0),
+                        new SortableTestRow(null, LocalDate.of(2026, 1, 1), 0),
+                        -1
+                ),
+                Arguments.of(
+                        new SortableTestRow(null, LocalDate.of(2026, 1, 1), 0),
+                        new SortableTestRow(null, LocalDate.of(2026, 1, 1), 0),
+                        0
+                ),
+                Arguments.of(
+                        new SortableTestRow(1, null, 0),
+                        new SortableTestRow(1, LocalDate.of(2026, 1, 1), 0),
+                        1
+                ),
+                Arguments.of(
+                        new SortableTestRow(1, LocalDate.of(2026, 1, 1), 0),
+                        new SortableTestRow(1, null, 0),
+                        -1
+                ),
+                Arguments.of(
+                        new SortableTestRow(1, null, 0),
+                        new SortableTestRow(1, null, 0),
+                        0
+                ),
+                Arguments.of(null, null, 0),
+                Arguments.of(
+                        null,
+                        new SortableTestRow(1, LocalDate.of(2026, 1, 1), 0),
+                        1
+                ),
+                Arguments.of(
+                        new SortableTestRow(1, LocalDate.of(2026, 1, 1), 0),
+                        null,
+                        -1
+                )
+        );
+    }
+
+    private record SortableTestRow(Integer shareholderId, LocalDate date, Integer id) implements SortableExportRow {
+    }
+}


### PR DESCRIPTION
This MR adds the display ID of the shareholder to the XLSX export and sorts the entries by it, instead of sorting the entries by the name of the shareholder as was done previously.